### PR TITLE
, the dollar sign ($) has a special meaning in the replacement string…

### DIFF
--- a/infobip-spring-data-r2dbc-querydsl/src/main/java/com/infobip/spring/data/r2dbc/QuerydslParameterBinder.java
+++ b/infobip-spring-data-r2dbc-querydsl/src/main/java/com/infobip/spring/data/r2dbc/QuerydslParameterBinder.java
@@ -38,8 +38,16 @@ class QuerydslParameterBinder {
         var sqlWithParameterNames = sql;
 
         for (String parameterName : parameterNameToParameterValue.keySet()) {
-            sqlWithParameterNames = sqlWithParameterNames.replaceFirst("\\?", parameterName);
+            String paramName = escape(parameterName);
+            sqlWithParameterNames = sqlWithParameterNames.replaceFirst("\\?", paramName);
         }
         return sqlWithParameterNames;
+    }
+
+    private String escape(String parameterName) {
+        if (parameterName.startsWith("$")) {
+            return parameterName.replace("$", "\\$");
+        }
+        return parameterName;
     }
 }


### PR DESCRIPTION
…. It is used to reference captured groups from the regular expression pattern so that we need to replace $ with \\$ to avoid the "No group 1" error